### PR TITLE
Fix compilation errors

### DIFF
--- a/Ball.cpp
+++ b/Ball.cpp
@@ -1,4 +1,4 @@
-#include "GameObjects.h"
+#include "Ball.h"
 #include <cmath>
 
 float randInRange(float min, float max)

--- a/Ball.h
+++ b/Ball.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "GameObject.h"
+#include "Paddle.h"
+
+/**
+ * @brief Ball Game Object. Has collision and is a core component of the game
+ *
+ */
+class Ball : public GameObject
+{
+public:
+    typedef GameObject super;
+    float rad;
+
+    Ball();
+
+    Ball(float x, float y, float r, float xv, float yv);
+
+    void update(Paddle p1, Paddle p2);
+    void draw();
+    void reset();
+
+private:
+    float initialXPos;
+    float initialYPos;
+};
+

--- a/Boundary.cpp
+++ b/Boundary.cpp
@@ -1,4 +1,4 @@
-#include "GameObjects.h"
+#include "Boundary.h"
 
 typedef GameObject super;
 

--- a/Boundary.h
+++ b/Boundary.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "GameObject.h"
+
+/**
+ * @brief Boundary Game Object. Has collision and acts as a wall for both the ball and the paddles.
+ *
+ */
+class Boundary : public GameObject
+{
+public:
+    typedef GameObject super;
+
+    Boundary();
+    Boundary(float x, float y, float xl, float yl, float xv, float yv);
+
+    void draw();
+};

--- a/GameObject.cpp
+++ b/GameObject.cpp
@@ -1,4 +1,4 @@
-#include "GameObjects.h"
+#include "GameObject.h"
 
 GameObject::GameObject() {}
 
@@ -23,6 +23,8 @@ GameObject::GameObject(float xPos, float yPos, float xLen, float yLen, float xVe
 }
 
 GameObject::~GameObject() {}
+
+void GameObject::draw() {}
 
 bool GameObject::isColliding(GameObject other)
 {

--- a/GameObject.h
+++ b/GameObject.h
@@ -1,9 +1,6 @@
-#include <GL/glut.h>
+#pragma once
 
-struct GameObject;
-class Ball;
-class Paddle;
-class Boundary;
+#include <GL/glut.h>
 
 /**
  * @brief A struct that represents a game object. (everything on the screen)
@@ -37,7 +34,7 @@ public:
 
     GameObject();
     GameObject(float xPos, float yPos, float xLen, float yLen, float xVel, float yVel);
-    ~GameObject();
+    virtual ~GameObject();
 
     /**
      * @brief Function to draw the object on the screen.
@@ -65,59 +62,4 @@ public:
      * @return false if not colliding
      */
     bool isColliding(GameObject other);
-};
-
-/**
- * @brief Ball Game Object. Has collision and is a core component of the game
- *
- */
-class Ball : public GameObject
-{
-public:
-    typedef GameObject super;
-    float rad;
-
-    Ball();
-
-    Ball(float x, float y, float r, float xv, float yv);
-
-    void update(Paddle p1, Paddle p2);
-    void draw();
-    void reset();
-
-private:
-    float initialXPos;
-    float initialYPos;
-};
-
-/**
- * @brief Paddle Game Object. Has collision and is the playable part of the game.
- *
- */
-class Paddle : public GameObject
-{
-public:
-    typedef GameObject super;
-    float speed = 0.02f;
-
-    Paddle();
-    Paddle(float x, float y, float xl, float yl, float xv, float yv);
-
-    void draw();
-    void update();
-};
-
-/**
- * @brief Boundary Game Object. Has collision and acts as a wall for both the ball and the paddles.
- *
- */
-class Boundary : public GameObject
-{
-public:
-    typedef GameObject super;
-    
-    Boundary();
-    Boundary(float x, float y, float xl, float yl, float xv, float yv);
-
-    void draw();
 };

--- a/Paddle.cpp
+++ b/Paddle.cpp
@@ -1,4 +1,4 @@
-#include "GameObjects.h"
+#include "Paddle.h"
 
 Paddle::Paddle() {}
 

--- a/Paddle.h
+++ b/Paddle.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "GameObject.h"
+
+/**
+ * @brief Paddle Game Object. Has collision and is the playable part of the game.
+ *
+ */
+class Paddle : public GameObject
+{
+public:
+    typedef GameObject super;
+    float speed = 0.02f;
+
+    Paddle();
+    Paddle(float x, float y, float xl, float yl, float xv, float yv);
+
+    void draw();
+    void update();
+};

--- a/game.cpp
+++ b/game.cpp
@@ -2,7 +2,11 @@
 
 #include <cstdlib> // rand()
 
-#include "GameObjects.h"
+#include "Ball.h"
+#include "GameObject.h"
+#include "Paddle.h"
+#include "Boundary.h"
+
 
 #define SCREEN_WIDTH 720
 #define SCREEN_HEIGHT 720

--- a/makefile
+++ b/makefile
@@ -1,20 +1,19 @@
-CC=g++
+CXX=g++
 FLAGS=-lGL -lglut -lncurses
 
-HEADERS=GameObjects.h
-OBJECTS=GameObject.o Paddle.o Ball.o Boundary.o
+OBJECTS=GameObject.o Paddle.o Ball.o Boundary.o game.o
 EXES=game
 
 all: $(EXES)
 
 # Compile all executables
-game: $(OBJECTS) $(HEADERS)
-	$(CC) game.cpp -o game $(FLAGS)
+game: $(OBJECTS)
+	$(CXX) $(OBJECTS) -o game $(FLAGS)
 
 # Compile all object files
 # Dont ask me how this works, but it does. Thanks github copilot
-%.o: %.cpp $(HEADERS)
-	$(CC) -c $< -o $@
+%.o: %.cpp %.h
+	$(CXX) -c $< -o $@
 
 clean:
 	rm -f *.o $(EXES)


### PR DESCRIPTION
Takes GL imports out of headers, so they're in the implementation instead. Breaks single header file into one per class. Modifies Makefile to watch header files. Changes CC to CXX as it's c++.

Fixes #1 